### PR TITLE
♻ (Cont.) Implement CreateActionTypes by Type Inference in Conditional Types.

### DIFF
--- a/src/app/actions/login.ts
+++ b/src/app/actions/login.ts
@@ -27,9 +27,3 @@ export const loginFailure = (errorText: string) => ({
 export const logout = () => ({
   type: Type.LOGOUT,
 })
-
-export type LoginAction =
-  | ReturnType<typeof login>
-  | ReturnType<typeof loginSuccess>
-  | ReturnType<typeof loginFailure>
-  | ReturnType<typeof logout>

--- a/src/app/actions/login.ts
+++ b/src/app/actions/login.ts
@@ -8,15 +8,10 @@ export const Type = {
   LOGOUT: 'LOGIN/LOGOUT',
 } as const
 
-// bound action creator interfaces
-export type DispatchLogin = (id: string, password: string) => void
-export type DispatchLoginSuccess = (loginState: LoginState) => void
-export type DispatchLoginFailure = (errorCode: string) => void
-export type DispatchLogout = () => void
-
 // action creators
-export const login = () => ({
+export const login = (id: string, password: string) => ({
   type: Type.LOGIN,
+  payload: { id, password },
 })
 
 export const loginSuccess = ({ token, userId }: LoginState) => ({

--- a/src/app/actions/login.ts
+++ b/src/app/actions/login.ts
@@ -1,5 +1,5 @@
 import { LoginState } from '@/app/models/Login'
-import { CreateActionTypes } from '@/app/common/typeHelper'
+import { CreateActionTypes, CreateDispatcherTypes } from '@/app/common/typeHelper'
 
 // action types
 export const Type = {
@@ -30,3 +30,4 @@ export const logout = () => ({
 })
 
 export type LoginAction = CreateActionTypes<Omit<typeof import('./login'), 'Type'>>
+export type LoginDispatcher = CreateDispatcherTypes<Omit<typeof import('./login'), 'Type'>>

--- a/src/app/actions/login.ts
+++ b/src/app/actions/login.ts
@@ -1,4 +1,5 @@
 import { LoginState } from '@/app/models/Login'
+import { CreateActionTypes } from '@/app/common/typeHelper'
 
 // action types
 export const Type = {
@@ -27,3 +28,5 @@ export const loginFailure = (errorText: string) => ({
 export const logout = () => ({
   type: Type.LOGOUT,
 })
+
+export type LoginAction = CreateActionTypes<Omit<typeof import('./login'), 'Type'>>

--- a/src/app/actions/network.ts
+++ b/src/app/actions/network.ts
@@ -1,3 +1,5 @@
+import { CreateActionTypes } from '@/app/common/typeHelper'
+
 // action types
 export const Type = {
   INCREMENT_CONNECTION: 'NETWORK/INCREMENT_CONNECTION',
@@ -12,3 +14,5 @@ export const incrementConnection = () => ({
 export const decrementConnection = () => ({
   type: Type.DECREMENT_CONNECTION,
 })
+
+export type NetworkAction = CreateActionTypes<Omit<typeof import('./network'), 'Type'>>

--- a/src/app/actions/network.ts
+++ b/src/app/actions/network.ts
@@ -4,10 +4,6 @@ export const Type = {
   DECREMENT_CONNECTION: 'NETWORK/DECREMENT_CONNECTION',
 } as const
 
-// bound action creator interfaces
-export type DispatchIncrementConnection = () => void
-export type DispatchDecrementConnection = () => void
-
 // action creators
 export const incrementConnection = () => ({
   type: Type.INCREMENT_CONNECTION,

--- a/src/app/actions/network.ts
+++ b/src/app/actions/network.ts
@@ -12,5 +12,3 @@ export const incrementConnection = () => ({
 export const decrementConnection = () => ({
   type: Type.DECREMENT_CONNECTION,
 })
-
-export type NetworkAction = ReturnType<typeof incrementConnection> | ReturnType<typeof decrementConnection>

--- a/src/app/actions/network.ts
+++ b/src/app/actions/network.ts
@@ -1,4 +1,4 @@
-import { CreateActionTypes } from '@/app/common/typeHelper'
+import { CreateActionTypes, CreateDispatcherTypes } from '@/app/common/typeHelper'
 
 // action types
 export const Type = {
@@ -16,3 +16,4 @@ export const decrementConnection = () => ({
 })
 
 export type NetworkAction = CreateActionTypes<Omit<typeof import('./network'), 'Type'>>
+export type NetworkDispatchTypes = CreateDispatcherTypes<Omit<typeof import('./network'), 'Type'>>

--- a/src/app/actions/todo.ts
+++ b/src/app/actions/todo.ts
@@ -1,4 +1,4 @@
-import { TodoState, Todo } from '@/app/models/Todo'
+import { Todo } from '@/app/models/Todo'
 
 // action types
 export const Type = {
@@ -9,14 +9,6 @@ export const Type = {
   FETCH_TODOS_SUCCESS: 'TODOS/FETCH_TODOS_SUCCESS',
   FETCH_TODOS_FAILURE: 'TODOS/FETCH_TODOS_FAILURE',
 } as const
-
-// bound action creator interfaces
-export type DispatchAddTodo = (text: string) => void
-export type DispatchUpdateTodo = (todo: Todo) => void
-export type DispatchDeleteTodo = (todoId: string) => void
-export type DispatchFetchTodos = () => void
-export type DispatchFetchTodosSuccess = (todoState: TodoState) => void
-export type DispatchFetchTodosFailure = (errorCode: string) => void
 
 // action creators
 export const addTodo = (text: string) => ({

--- a/src/app/actions/todo.ts
+++ b/src/app/actions/todo.ts
@@ -1,4 +1,5 @@
 import { Todo } from '@/app/models/Todo'
+import { CreateActionTypes } from '@/app/common/typeHelper'
 
 // action types
 export const Type = {
@@ -39,3 +40,5 @@ export const fetchTodosFailure = (errorText: string) => ({
   type: Type.FETCH_TODOS_FAILURE,
   payload: { errorText },
 })
+
+export type TodoAction = CreateActionTypes<Omit<typeof import('./todo'), 'Type'>>

--- a/src/app/actions/todo.ts
+++ b/src/app/actions/todo.ts
@@ -39,11 +39,3 @@ export const fetchTodosFailure = (errorText: string) => ({
   type: Type.FETCH_TODOS_FAILURE,
   payload: { errorText },
 })
-
-export type TodoAction =
-  | ReturnType<typeof addTodo>
-  | ReturnType<typeof updateTodo>
-  | ReturnType<typeof deleteTodo>
-  | ReturnType<typeof fetchTodos>
-  | ReturnType<typeof fetchTodosSuccess>
-  | ReturnType<typeof fetchTodosFailure>

--- a/src/app/actions/todo.ts
+++ b/src/app/actions/todo.ts
@@ -1,5 +1,5 @@
 import { Todo } from '@/app/models/Todo'
-import { CreateActionTypes } from '@/app/common/typeHelper'
+import { CreateActionTypes, CreateDispatcherTypes } from '@/app/common/typeHelper'
 
 // action types
 export const Type = {
@@ -42,3 +42,4 @@ export const fetchTodosFailure = (errorText: string) => ({
 })
 
 export type TodoAction = CreateActionTypes<Omit<typeof import('./todo'), 'Type'>>
+export type TodoDispatcher = CreateDispatcherTypes<Omit<typeof import('./todo'), 'Type'>>

--- a/src/app/common/typeHelper.ts
+++ b/src/app/common/typeHelper.ts
@@ -3,3 +3,7 @@ type ExtractFunctionReturnTypes<T> = { [K in keyof T]: T[K] extends (...args: an
 type Unbox<T> = T extends { [K in keyof T]: infer U } ? U : never
 
 export type CreateActionTypes<T> = Unbox<ExtractFunctionReturnTypes<T>>
+
+export type CreateDispatcherTypes<T> = {
+  [K in keyof T]: T[K] extends (...args: any) => any ? (...args: Parameters<T[K]>) => void : never
+}

--- a/src/app/common/typeHelper.ts
+++ b/src/app/common/typeHelper.ts
@@ -1,0 +1,5 @@
+type ExtractFunctionReturnTypes<T> = { [K in keyof T]: T[K] extends (...args: any) => any ? ReturnType<T[K]> : never }
+
+type Unbox<T> = T extends { [K in keyof T]: infer U } ? U : never
+
+export type CreateActionTypes<T> = Unbox<ExtractFunctionReturnTypes<T>>

--- a/src/app/common/typeHelper.ts
+++ b/src/app/common/typeHelper.ts
@@ -1,9 +1,26 @@
-type ExtractFunctionReturnTypes<T> = { [K in keyof T]: T[K] extends (...args: any) => any ? ReturnType<T[K]> : never }
-
+// General
 type Unbox<T> = T extends { [K in keyof T]: infer U } ? U : never
+
+// Actions
+interface Action {
+  type: any
+  payload?: any
+}
+
+type ActionCreator = (...args: any) => Action
+type IsActionCreator<T> = T extends ActionCreator ? T : never
+
+type ExtractFunctionReturnType<T> = ReturnType<IsActionCreator<T>>
+
+type ExtractFunctionReturnTypes<T> = {
+  [K in keyof T]: ExtractFunctionReturnType<T[K]>
+}
 
 export type CreateActionTypes<T> = Unbox<ExtractFunctionReturnTypes<T>>
 
+type ExtractFunctionParameterType<T> = Parameters<IsActionCreator<T>>
+type CreateDispatcherType<T> = (...args: ExtractFunctionParameterType<T>) => void
+
 export type CreateDispatcherTypes<T> = {
-  [K in keyof T]: T[K] extends (...args: any) => any ? (...args: Parameters<T[K]>) => void : never
+  [K in keyof T]: CreateDispatcherType<T[K]>
 }

--- a/src/app/containers/Login/index.tsx
+++ b/src/app/containers/Login/index.tsx
@@ -5,7 +5,7 @@ import { faSignInAlt } from '@fortawesome/free-solid-svg-icons'
 
 import { Header } from '@/app/components/Header'
 import { Footer } from '@/app/components/Footer'
-import { login } from '@/app/actions/login'
+import { login, LoginDispatcher } from '@/app/actions/login'
 import { RootState } from '@/app/models'
 import { paths } from '@/app/common/paths'
 import words from '@/assets/strings'
@@ -16,7 +16,7 @@ interface StateProps {
 }
 
 interface DispatchProps {
-  readonly login: typeof login
+  readonly login: LoginDispatcher['login']
 }
 
 type LoginProps = StateProps & DispatchProps & RouteComponentProps

--- a/src/app/containers/Login/index.tsx
+++ b/src/app/containers/Login/index.tsx
@@ -5,7 +5,7 @@ import { faSignInAlt } from '@fortawesome/free-solid-svg-icons'
 
 import { Header } from '@/app/components/Header'
 import { Footer } from '@/app/components/Footer'
-import { login, DispatchLogin } from '@/app/actions/login'
+import { login } from '@/app/actions/login'
 import { RootState } from '@/app/models'
 import { paths } from '@/app/common/paths'
 import words from '@/assets/strings'
@@ -16,7 +16,7 @@ interface StateProps {
 }
 
 interface DispatchProps {
-  readonly login: DispatchLogin
+  readonly login: typeof login
 }
 
 type LoginProps = StateProps & DispatchProps & RouteComponentProps

--- a/src/app/containers/TodoApp/index.tsx
+++ b/src/app/containers/TodoApp/index.tsx
@@ -2,8 +2,8 @@ import React, { FC, useState, useEffect, useRef, ChangeEvent, KeyboardEvent } fr
 import { connect } from 'react-redux'
 import { faListAlt, faPlusCircle } from '@fortawesome/free-solid-svg-icons'
 
-import { logout } from '@/app/actions/login'
-import { addTodo, updateTodo, deleteTodo, fetchTodos } from '@/app/actions/todo'
+import { logout, LoginDispatcher } from '@/app/actions/login'
+import { addTodo, updateTodo, deleteTodo, fetchTodos, TodoDispatcher } from '@/app/actions/todo'
 import { Header } from '@/app/components/Header'
 import { TodoItem } from '@/app/components/TodoItem'
 import { ListWrapper } from '@/app/components/ListWrapper'
@@ -22,11 +22,11 @@ interface StateProps {
 }
 
 interface DispatchProps {
-  readonly addTodo: typeof addTodo
-  readonly updateTodo: typeof updateTodo
-  readonly deleteTodo: typeof deleteTodo
-  readonly fetchTodos: typeof fetchTodos
-  readonly logout: typeof logout
+  readonly addTodo: TodoDispatcher['addTodo']
+  readonly updateTodo: TodoDispatcher['updateTodo']
+  readonly deleteTodo: TodoDispatcher['deleteTodo']
+  readonly fetchTodos: TodoDispatcher['fetchTodos']
+  readonly logout: LoginDispatcher['logout']
 }
 
 type TodoAppProps = StateProps & DispatchProps

--- a/src/app/containers/TodoApp/index.tsx
+++ b/src/app/containers/TodoApp/index.tsx
@@ -2,17 +2,8 @@ import React, { FC, useState, useEffect, useRef, ChangeEvent, KeyboardEvent } fr
 import { connect } from 'react-redux'
 import { faListAlt, faPlusCircle } from '@fortawesome/free-solid-svg-icons'
 
-import { logout, DispatchLogout } from '@/app/actions/login'
-import {
-  addTodo,
-  DispatchAddTodo,
-  updateTodo,
-  DispatchUpdateTodo,
-  deleteTodo,
-  DispatchDeleteTodo,
-  fetchTodos,
-  DispatchFetchTodos,
-} from '@/app/actions/todo'
+import { logout } from '@/app/actions/login'
+import { addTodo, updateTodo, deleteTodo, fetchTodos } from '@/app/actions/todo'
 import { Header } from '@/app/components/Header'
 import { TodoItem } from '@/app/components/TodoItem'
 import { ListWrapper } from '@/app/components/ListWrapper'
@@ -31,11 +22,11 @@ interface StateProps {
 }
 
 interface DispatchProps {
-  readonly addTodo: DispatchAddTodo
-  readonly updateTodo: DispatchUpdateTodo
-  readonly deleteTodo: DispatchDeleteTodo
-  readonly fetchTodos: DispatchFetchTodos
-  readonly logout: DispatchLogout
+  readonly addTodo: typeof addTodo
+  readonly updateTodo: typeof updateTodo
+  readonly deleteTodo: typeof deleteTodo
+  readonly fetchTodos: typeof fetchTodos
+  readonly logout: typeof logout
 }
 
 type TodoAppProps = StateProps & DispatchProps

--- a/src/app/reducers/login.ts
+++ b/src/app/reducers/login.ts
@@ -1,7 +1,11 @@
 import { Reducer } from 'redux'
-import { LoginAction, Type } from '@/app/actions/login'
+import * as LoginActionModule from '@/app/actions/login'
 import { LoginState } from '@/app/models/Login'
 import { paths } from '@/app/common/paths'
+import { CreateActionTypes } from '@/app/common/typeHelper'
+
+const { Type } = LoginActionModule
+type LoginAction = CreateActionTypes<typeof LoginActionModule>
 
 const defaultState: LoginState = {
   token: localStorage.getItem('token') || '',

--- a/src/app/reducers/login.ts
+++ b/src/app/reducers/login.ts
@@ -1,11 +1,7 @@
 import { Reducer } from 'redux'
-import * as LoginActionModule from '@/app/actions/login'
+import { Type, LoginAction } from '@/app/actions/login'
 import { LoginState } from '@/app/models/Login'
 import { paths } from '@/app/common/paths'
-import { CreateActionTypes } from '@/app/common/typeHelper'
-
-const { Type } = LoginActionModule
-type LoginAction = CreateActionTypes<typeof LoginActionModule>
 
 const defaultState: LoginState = {
   token: localStorage.getItem('token') || '',

--- a/src/app/reducers/network.ts
+++ b/src/app/reducers/network.ts
@@ -1,6 +1,10 @@
 import { Reducer } from 'redux'
-import { NetworkAction, Type } from '@/app/actions/network'
+import * as NetworkActionModule from '@/app/actions/network'
 import { NetworkState } from '@/app/models/Network'
+import { CreateActionTypes } from '@/app/common/typeHelper'
+
+const { Type } = NetworkActionModule
+type NetworkAction = CreateActionTypes<typeof NetworkActionModule>
 
 const defaultState: NetworkState = {
   connectionCount: 0,

--- a/src/app/reducers/network.ts
+++ b/src/app/reducers/network.ts
@@ -1,10 +1,6 @@
 import { Reducer } from 'redux'
-import * as NetworkActionModule from '@/app/actions/network'
+import { Type, NetworkAction } from '@/app/actions/network'
 import { NetworkState } from '@/app/models/Network'
-import { CreateActionTypes } from '@/app/common/typeHelper'
-
-const { Type } = NetworkActionModule
-type NetworkAction = CreateActionTypes<typeof NetworkActionModule>
 
 const defaultState: NetworkState = {
   connectionCount: 0,

--- a/src/app/reducers/todo.ts
+++ b/src/app/reducers/todo.ts
@@ -1,7 +1,11 @@
 import { Reducer } from 'redux'
 import uuid from 'uuidv4'
-import { TodoAction, Type } from '@/app/actions/todo'
+import * as TodoActionModule from '@/app/actions/todo'
 import { TodoState, Todo } from '@/app/models/Todo'
+import { CreateActionTypes } from '@/app/common/typeHelper'
+
+const { Type } = TodoActionModule
+type TodoAction = CreateActionTypes<typeof TodoActionModule>
 
 const defaultState: TodoState = {
   todos: [],

--- a/src/app/reducers/todo.ts
+++ b/src/app/reducers/todo.ts
@@ -1,11 +1,7 @@
 import { Reducer } from 'redux'
 import uuid from 'uuidv4'
-import * as TodoActionModule from '@/app/actions/todo'
+import { Type, TodoAction } from '@/app/actions/todo'
 import { TodoState, Todo } from '@/app/models/Todo'
-import { CreateActionTypes } from '@/app/common/typeHelper'
-
-const { Type } = TodoActionModule
-type TodoAction = CreateActionTypes<typeof TodoActionModule>
 
 const defaultState: TodoState = {
   todos: [],


### PR DESCRIPTION
PR: #347 の改修案提示。
手元であれこれ触ってみたかったのでブランチコピーして直接手を入れてみました。

issue #346 

* actionTypes の生成処理を reducer 側ではなく action のレイヤーに移動した
  * やはり actionType を生成する責務は action 側にあると思ったので、DRY に書けるメリットは残しつつ移動した
* Container component 向けの dispatcher type を生成するための `CreateDispatcherTypes` を作成した
  * actionCreator と同等の引数型を持ちつつ戻り型 void の関数型を生成できるようになった
